### PR TITLE
Switch from OpenSSL to rustls for TLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simpath"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 description = "Search for files on a path defined in an environment variable"
 license = "MIT"
@@ -16,7 +16,7 @@ urls = ["url", "curl"]
 
 [dependencies]
 url = { version = "~2.2", optional = true }
-curl = { version = "~0.4", optional = true }
+curl = { version = "~0.4", optional = true, default-features = false, features = ["rustls"] }
 
 [dev-dependencies]
 tempdir = "~0.3.5"


### PR DESCRIPTION
## Summary
Switch curl dependency from default OpenSSL TLS backend to rustls. This eliminates the `openssl-sys` dependency entirely, making cross-compilation (e.g. for Raspberry Pi armv7) much simpler — no need to provide OpenSSL headers for the target platform.

Bumps version to 2.6.0.

## Changes
- `curl` dependency: add `default-features = false, features = ["rustls"]`
- The `urls` feature still works the same way, just uses rustls under the hood

## Test plan
- [x] `cargo test --features urls` passes
- [x] `cargo tree --features urls -i openssl-sys` confirms openssl-sys is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)